### PR TITLE
fix: remove the `hts-sys/` subpath from `--manifest-path` specification

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,4 +40,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: publish
-          args: --manifest-path hts-sys/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }}
+          args: --manifest-path Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This was probably a leftover from when `hts-sys` was a subfolder of the `rust-htslib` repo.