### PR TITLE
chore(deps): update libdeflate-sys to 1.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libz-sys = { version = "1.1.0", default-features = false, features = ["zlib-ng",
 bzip2-sys = { version = "0.1.8", optional = true }
 lzma-sys = { version = "0.1.16", optional = true, features = ["static"] }
 curl-sys = { version = "0.4.44", optional = true, features = ["static-curl", "static-ssl", "protocol-ftp"] }
-libdeflate-sys = { version = "0.7.3", optional = true }
+libdeflate-sys = { version = "1.21.0", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl-sys = { version = "0.9.56", optional = true }


### PR DESCRIPTION
Updates to libdeflate have fixed bugs, added more CPU support, and increased performance (see e.g. https://github.com/ebiggers/libdeflate/blob/master/NEWS.md#version-114 ). Personally, I use `rust-htslib` in a context where BAM read/decompression speed is a major performance factor, so having the ~20-30% performance increase from at least v1.14 would be quite useful. 

Closes #15. 