### PR TITLE
Better bgzf_tell

### DIFF
--- a/wrapper.c
+++ b/wrapper.c
@@ -20,3 +20,7 @@ void wrap_kbs_destroy(kbitset_t *bs)
 {
   kbs_destroy(bs);
 }
+
+int64_t wrap_bgzf_tell(BGZF *fp) {
+    return bgzf_tell(fp);
+}

--- a/wrapper.h
+++ b/wrapper.h
@@ -11,6 +11,8 @@
 #include "htslib/htslib/faidx.h"
 #include "htslib/htslib/thread_pool.h"
 
+#include <stdint.h>
+
 // The following functions have to be wrapped here because they are inline in htslib.
 
 /**
@@ -34,3 +36,9 @@ void wrap_kbs_insert(kbitset_t *bs, int i);
  * <div rustbindgen replaces="kbs_destroy"></div>
  */
 void wrap_kbs_destroy(kbitset_t *bs);
+
+
+/**
+ * <div rustbindgen replaces="bgzf_tell"></div>
+ */
+int64_t wrap_bgzf_tell(BGZF *fp);


### PR DESCRIPTION
Hi hts-sys maintainers (hope you are still around),

I added a small shim that allows rust-htslib to link to htslib > 1.19.
This replaces the now prohibited re-implementation of bgzf_tell in Rust. 
