### PR TITLE
fix: update bindgen to support clang 22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,6 @@ static = [] # Don't dynamically link to other libraries
 
 [build-dependencies]
 fs-utils = "1.1"
-bindgen = { version = "0.71.1", default-features = false, features = ["runtime"], optional = true }
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"], optional = true }
 cc = { version = "1.0", features = ["parallel"] }
 glob = "0.3.0"


### PR DESCRIPTION
Updates binden to 0.72.1 . This allows to use clang 22, which is for example used now on bioconda if clandev is used without a version constraint. 

At the moment packages that use hts-sys or rust htslib are not able to build with default settings on bioconda. 

See https://github.com/rust-lang/rust-bindgen/issues/3264
Fixes #31 